### PR TITLE
Adding new collate_fn for dataloaders

### DIFF
--- a/src/cata2data/utils.py
+++ b/src/cata2data/utils.py
@@ -11,3 +11,14 @@ def collate_fn_irregular_cutouts(batch):
         y = torch.as_tensor(y)
     x = [torch.as_tensor(sample) for sample in x]
     return x, y
+
+def collate_fn_regular_cutouts(batch):
+    # Convert tuple of (x,y) tuples to tuple of x and y lists.
+    x, y = list(zip(*batch))
+    # if y is arraylike
+    if isinstance(y[0], np.ndarray) or isinstance(y[0], list):
+        y = torch.as_tensor(np.concatenate([target.astype(np.float32) for target in y]))
+    else:
+        y = torch.as_tensor(y)
+    x = torch.stack([sample for sample in x])
+    return x, y


### PR DESCRIPTION
Fixing #23 by introducing a `collate_fn_regular_cutouts` function which behaves as expected of the default `collate_fn.