### PR TITLE
resolves Issue with python 3.12 install 

### DIFF
--- a/.github/workflows/install_and_test.yaml
+++ b/.github/workflows/install_and_test.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "astropy==5.2.1",
+  "astropy==5.3.4",
   "beautifulsoup4",
-  "matplotlib==3.6.3",
-  "numpy==1.24.2",
-  "pandas==1.5.3",
+  "matplotlib",
+  "numpy<2",
+  "pandas",
   "regions==0.7",
   "requests",
   "spectral-cube==0.6.0",


### PR DESCRIPTION
- allows CI testing by altering versions of dependencies defined in pyproject.toml
- close #36 